### PR TITLE
Allow for interpolation chaining with hooks and TypeScript

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -19,83 +19,83 @@
     "gzipped": 1990
   },
   "dist/web.js": {
-    "bundled": 75825,
-    "minified": 36044,
-    "gzipped": 11686,
+    "bundled": 76049,
+    "minified": 36091,
+    "gzipped": 11709,
     "treeshaked": {
       "rollup": {
-        "code": 30418,
+        "code": 30465,
         "import_statements": 287
       },
       "webpack": {
-        "code": 31818
+        "code": 31865
       }
     }
   },
   "dist/web.umd.js": {
-    "bundled": 81489,
-    "minified": 32103,
-    "gzipped": 11503
+    "bundled": 81727,
+    "minified": 32150,
+    "gzipped": 11528
   },
   "dist/native.js": {
-    "bundled": 71944,
-    "minified": 33557,
-    "gzipped": 10299,
+    "bundled": 72168,
+    "minified": 33604,
+    "gzipped": 10326,
     "treeshaked": {
       "rollup": {
-        "code": 26924,
+        "code": 26971,
         "import_statements": 298
       },
       "webpack": {
-        "code": 28273
+        "code": 28320
       }
     }
   },
   "dist/universal.js": {
-    "bundled": 57896,
-    "minified": 26193,
-    "gzipped": 7532,
+    "bundled": 58120,
+    "minified": 26240,
+    "gzipped": 7553,
     "treeshaked": {
       "rollup": {
-        "code": 19581,
+        "code": 19628,
         "import_statements": 262
       },
       "webpack": {
-        "code": 20850
+        "code": 20897
       }
     }
   },
   "dist/konva.js": {
-    "bundled": 69049,
-    "minified": 32156,
-    "gzipped": 10227,
+    "bundled": 69273,
+    "minified": 32203,
+    "gzipped": 10251,
     "treeshaked": {
       "rollup": {
-        "code": 26894,
+        "code": 26941,
         "import_statements": 262
       },
       "webpack": {
-        "code": 28217
+        "code": 28264
       }
     }
   },
   "dist/hooks.js": {
-    "bundled": 79356,
-    "minified": 37758,
-    "gzipped": 12202,
+    "bundled": 79357,
+    "minified": 37761,
+    "gzipped": 12226,
     "treeshaked": {
       "rollup": {
         "code": 16351,
         "import_statements": 341
       },
       "webpack": {
-        "code": 28369
+        "code": 28393
       }
     }
   },
   "dist/hooks.umd.js": {
-    "bundled": 85798,
-    "minified": 33820,
-    "gzipped": 12032
+    "bundled": 85799,
+    "minified": 33805,
+    "gzipped": 12040
   }
 }

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -30,25 +30,35 @@ type ExcludedProps =
   | 'autoStart'
   | 'ref'
 
-export type InterpolationOptions<T, U = T> = {
+// The config options for an interoplation. It maps out from in "in" type
+// to an "out" type.
+export type InterpolationConfig<T, U = T> = {
   range: T[]
   output: U[]
 }
 
-export interface InterpolationFn<T> {
-  <U>(options: InterpolationOptions<T, U>): OpaqueInterpolation<U>
+// The InterpolationChain is either a function that takes a config object
+// and returns the next chainable type or it is a function that takes in params
+// and maps out to another InterpolationChain.
+export interface InterpolationChain<T> {
+  <U>(config: InterpolationConfig<T, U>): OpaqueInterpolation<U>
   <U>(interpolator: (params: T) => U): OpaqueInterpolation<U>
 }
 
+// The opaque interpolation masks as its original type but provides to helpers
+// for chaining the interpolate method and getting its raw value.
 export type OpaqueInterpolation<T> = {
-  interpolate: InterpolationFn<T>
+  interpolate: InterpolationChain<T>
   getValue: () => T
 } & T
 
+// Map all keys to our OpaqueInterpolation type which can either be interpreted
+// as its initial value by "animated.{tag}" or chained with interpolations.
 export type AnimatedValue<T extends object> = {
   [P in keyof T]: OpaqueInterpolation<T[P]>
 }
 
+// Make ForwardedProps chainable with interpolate / make it an animated value.
 export type ForwardedProps<T> = AnimatedValue<
   Pick<T, Exclude<keyof T, ExcludedProps>>
 >

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -59,9 +59,8 @@ export type AnimatedValue<T extends object> = {
 }
 
 // Make ForwardedProps chainable with interpolate / make it an animated value.
-export type ForwardedProps<T> = AnimatedValue<
-  Pick<T, Exclude<keyof T, ExcludedProps>>
->
+export type ForwardedProps<T> = Pick<T, Exclude<keyof T, ExcludedProps>>
+
 // NOTE: because of the Partial, this makes a weak type, which can have excess props
 type InferFrom<T extends object> = T extends { to: infer TTo }
   ? Partial<TTo>
@@ -101,20 +100,20 @@ export type UseSpringProps<DS extends UseSpringBaseProps> = Merge<
 // there's a third value in the tuple but it's not public API (?)
 export function useSpring<DS extends object>(
   getProps: () => UseSpringProps<DS>
-): [ForwardedProps<DS>, SetUpdateFn<DS>]
+): [AnimatedValue<ForwardedProps<DS>>, SetUpdateFn<DS>]
 export function useSpring<DS extends object>(
   values: UseSpringProps<DS>
-): ForwardedProps<DS>
+): AnimatedValue<ForwardedProps<DS>>
 
 // there's a third value in the tuple but it's not public API (?)
 export function useTrail<DS extends object>(
   count: number,
   getProps: () => UseSpringProps<DS>
-): [ForwardedProps<DS>[], SetUpdateFn<DS>]
+): [AnimatedValue<ForwardedProps<DS>>[], SetUpdateFn<DS>]
 export function useTrail<DS extends object>(
   count: number,
   values: UseSpringProps<DS>
-): ForwardedProps<DS>[] // safe to modify (result of .map)
+): AnimatedValue<ForwardedProps<DS>>[] // safe to modify (result of .map)
 
 export interface UseTransitionProps<TItem, DS extends object>
   extends HooksBaseProps {
@@ -163,12 +162,12 @@ export interface UseTransitionResult<TItem, DS extends object> {
   item: TItem
   key: string
   state: State
-  props: ForwardedProps<DS>
+  props: AnimatedValue<ForwardedProps<DS>>
 }
 
 export function useTransition<TItem, DS extends object>(
   values: Merge<DS, UseTransitionProps<TItem, DS>>
-): UseTransitionResult<TItem, ForwardedProps<DS>>[] // result array is safe to modify
+): UseTransitionResult<TItem, AnimatedValue<ForwardedProps<DS>>>[] // result array is safe to modify
 
 // higher order hooks 🤯
 export namespace useKeyframes {
@@ -250,7 +249,9 @@ export namespace useKeyframes {
       slot: TSlot
     ) => ForwardedProps<ResolveKeyframeSlotValue<TSlots[TSlot]>>
   // this one crashes "even more" because both values are undefined
-  export type UseSpringKeyframes<DS extends object> = () => ForwardedProps<DS>
+  export type UseSpringKeyframes<DS extends object> = () => AnimatedValue<
+    ForwardedProps<DS>
+  >
 
   export type UseTrailKeyframesWithSlots<TSlots extends object> = <
     TSlot extends Exclude<keyof TSlots, keyof TrailKeyframeSlotsConfig<any>>
@@ -261,5 +262,5 @@ export namespace useKeyframes {
 
   export type UseTrailKeyframes<DS extends object> = (
     count: number
-  ) => ForwardedProps<DS>[]
+  ) => AnimatedValue<ForwardedProps<DS>>[]
 }

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -71,7 +71,9 @@ type InferFrom<T extends object> = T extends { to: infer TTo }
 //  but with a delayed evaluation that still allows A to be inferrable
 type Merge<A, B> = { [K in keyof A]: K extends keyof B ? B[K] : A[K] } & B
 
-export type SetUpdateFn<DS extends object> = (ds: DS) => void
+export type SetUpdateFn<DS extends object> = (
+  ds: Pick<DS, Exclude<keyof DS, ExcludedProps>>
+) => void
 
 // The hooks do emulate React's 'ref' by accepting { ref?: React.RefObject<Controller> } and
 // updating it. However, there are no types for Controller, and I assume it is intentionally so.

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -36,8 +36,8 @@ export type InterpolationOptions<T, U = T> = {
 }
 
 export interface InterpolationFn<T> {
-  <U>(options: InterpolationOptions<T, U>): OpaqueInterpolation<U> & U & string
-  (interpolator: (params: T) => string): OpaqueInterpolation<T> & T & string
+  <U>(options: InterpolationOptions<T, U>): OpaqueInterpolation<U> & U
+  <U>(interpolator: (params: T) => U): OpaqueInterpolation<U> & U
 }
 
 export type OpaqueInterpolation<T> = {

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -29,7 +29,29 @@ type ExcludedProps =
   | 'interpolateTo'
   | 'autoStart'
   | 'ref'
-export type ForwardedProps<T> = Pick<T, Exclude<keyof T, ExcludedProps>>
+
+export type InterpolationOptions<T, U = T> = {
+  range: T[]
+  output: U[]
+}
+
+export interface InterpolationFn<T> {
+  <U>(options: InterpolationOptions<T, U>): OpaqueInterpolation<U> & U & string
+  (interpolator: (params: T) => string): OpaqueInterpolation<T> & T & string
+}
+
+export type OpaqueInterpolation<T> = {
+  interpolate: InterpolationFn<T>
+  getValue: () => T
+}
+
+export type AnimatedValue<T extends object> = {
+  [P in keyof T]: OpaqueInterpolation<T[P]> & string
+}
+
+export type ForwardedProps<T> = AnimatedValue<
+  Pick<T, Exclude<keyof T, ExcludedProps>>
+>
 // NOTE: because of the Partial, this makes a weak type, which can have excess props
 type InferFrom<T extends object> = T extends { to: infer TTo }
   ? Partial<TTo>

--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -36,17 +36,17 @@ export type InterpolationOptions<T, U = T> = {
 }
 
 export interface InterpolationFn<T> {
-  <U>(options: InterpolationOptions<T, U>): OpaqueInterpolation<U> & U
-  <U>(interpolator: (params: T) => U): OpaqueInterpolation<U> & U
+  <U>(options: InterpolationOptions<T, U>): OpaqueInterpolation<U>
+  <U>(interpolator: (params: T) => U): OpaqueInterpolation<U>
 }
 
 export type OpaqueInterpolation<T> = {
   interpolate: InterpolationFn<T>
   getValue: () => T
-}
+} & T
 
 export type AnimatedValue<T extends object> = {
-  [P in keyof T]: OpaqueInterpolation<T[P]> & string
+  [P in keyof T]: OpaqueInterpolation<T[P]>
 }
 
 export type ForwardedProps<T> = AnimatedValue<


### PR DESCRIPTION
This PR adds an Opaque type that wraps `ForwardedRef` in the `react-spring` `hooks.d.ts` file. This allows for a type to be returned whose properties can be interpreted as valid CSS Properties as well as a type which can be interpolated.

eg:

```tsx
import { useSpring, animated } from 'react-spring/hooks';

interface Props {
  open?: boolean;
}

function App({ open = false }) {
  const { xy } = useSpring({
    xy: open ? [0, 0] : [1, 1],
  });

  // [number, number] => string
  const interpolateTransform = ([x, y]: [number, number]) => {
    return `translate3d(${x * 10}, ${y * 10}, 0px) scale(${x})`;
  };

  // [number, number] => number
  const interpolateBackgroundColor = ([x]: [number, number]) =>{
    return x;
  };

  return (
    <animated.div
      style={{
        backgroundColor: xy                               // [number, number]
          .interpolate(interpolateBackgroundColor)        // number
          .interpolate({
            range: [0, 1],
            output: ['#fff', '#000']
          }),                                             // string
        transform: xy.interpolate(interpolateTransform),  //string
      }}
    />
  );
}
```

*Additionally*, I've updated `SetUpdateFn` to exclude requiring the reserved words defined in `ExcludedProps`.