### PR TITLE
Fix `from` property type for `useTransition`

### DIFF
--- a/types/hooks.d.ts
+++ b/types/hooks.d.ts
@@ -108,7 +108,7 @@ export interface UseTransitionProps<TItem, DS extends object>
    */
   trail?: number
 
-  from?: InferFrom<DS>
+  from?: InferFrom<DS> | ((item: TItem) => InferFrom<DS>)
   /**
    * Values that apply to new elements, or: item => values
    * @default {}


### PR DESCRIPTION
Looks like this behavior was fixed in 38d26a1cb7c27fdb4587a35477caae226833bafa but the typings weren't updated to reflect that.