### PR TITLE
Add SpringBaseProps inheritance to SpringProps interface

### DIFF
--- a/types/universal.d.ts
+++ b/types/universal.d.ts
@@ -64,7 +64,7 @@ export interface SpringBaseProps {
   onStart?(): void
 }
 
-export interface SpringProps<DS extends object = {}> {
+export interface SpringProps<DS extends object = {}> extends SpringBaseProps {
   /**
    * Base styles
    * @default {}


### PR DESCRIPTION
This PR fixes the issue regarding #386.
I believe `SpringProps` was intended to inherit `SpringBaseProps` but was mistakenly not done so. This fix let's me add props like `config` to my `Spring` components.