### PR TITLE
Updating typescript for Transition component

### DIFF
--- a/types/universal.d.ts
+++ b/types/universal.d.ts
@@ -146,7 +146,7 @@ export interface TransitionProps<
    * Spring config, or for individual keys: fn((item,type) => config), where "type" can be either enter, leave or update
    * @default config.default
    */
-  config?: SpringConfig | ((item: TItem, state: State) => SpringConfig)
+  config?: SpringConfig | ((item: TItem, type: State) => SpringConfig)
   /**
    * First-render initial values, if present overrides "from" on the first render pass. It can be "null" to skip first mounting transition. Otherwise it can take an object or a function (item => object)
    */


### PR DESCRIPTION
Current typings for the TransitionProp use the `config` from Spring, I just separated the two in the same manner that it was separated on HooksBaseProps.