### PR TITLE
Emphasize docs in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ For a more detailed explanation read [Why React needed yet another animation lib
 
 # Documentation and Examples
 
-Full documentation and examples here: [react-spring.surge.sh](https://react-spring.github.io)
+Full documentation and examples here: **[react-spring.surge.sh](https://react-spring.github.io)**
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ For a more detailed explanation read [Why React needed yet another animation lib
 
 # Documentation and Examples
 
-Full documentation and examples here: **[react-spring.surge.sh](https://react-spring.github.io)**
+Full documentation and examples here: **[react-spring.surge.sh](https://react-spring.surge.sh/)**
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,11 @@ React-spring is a spring physics based animation library for React.
 
 For a more detailed explanation read [Why React needed yet another animation library](https://medium.com/@drcmda/why-react-needed-yet-another-animation-library-introducing-react-spring-8212e424c5ce).
 
+# Documentation and Examples
+
 Full documentation and examples here: [react-spring.surge.sh](https://react-spring.github.io)
+
+---
 
 # What others say
 


### PR DESCRIPTION
I use React Spring quite a bit these days, which means I'm often looking to check the docs for specific APIs. And for some reason, I always have a really tough time actually finding them! 

The docs site doesn't show up at all when you google "React spring docs":

<img width="1105" alt="docs" src="https://user-images.githubusercontent.com/6692932/51074728-65a4ba80-1650-11e9-9e27-7dd5359c89e6.png">

After clicking "Documentation" in that first result, I wind up in this repo, except it's a bunch of markdown files. So I navigate up to the main README, and scroll around looking for the link to the docs. This takes me several tries, since my quick-scanning brain totally misses this link:

<img width="978" alt="easytomiss" src="https://user-images.githubusercontent.com/6692932/51074744-ae5c7380-1650-11e9-98c1-4cb76df9e068.png">

Here's what it looks like in this PR:

<img width="976" alt="screen shot 2019-01-12 at 10 03 32 am" src="https://user-images.githubusercontent.com/6692932/51074792-5b36f080-1651-11e9-996d-65dd0f1ebad8.png">


I know doing READMEs is tricky because you're trying to match several usecases at once, from the beginner who doesn't know what this even is, to the returning users looking for the API reference docs. But I think the docs/examples are universally a good thing to highlight, especially when they're as nice as the ones you built!