### PR TITLE
Updating onDestroyed typing on TransitionProps

### DIFF
--- a/src/Transition.js
+++ b/src/Transition.js
@@ -19,7 +19,7 @@ export default class Transition extends React.PureComponent {
     initial: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     /** Base values (from -> enter), or: item => values */
     from: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
-    /** Values that apply to new elements, or: fitem => values */
+    /** Values that apply to new elements, or: item => values */
     enter: PropTypes.oneOfType([
       PropTypes.object,
       PropTypes.array,

--- a/types/universal.d.ts
+++ b/types/universal.d.ts
@@ -201,7 +201,7 @@ export interface TransitionProps<
   /**
    * Calls back once a transition is about to wrap up
    */
-  onDestroyed?: () => void
+  onDestroyed?: (item: TItem) => void
   /**
    * Useful in combination with "unique", when true it forces incoming items that already exist to restart instead of adapting to their current values
    * @default false

--- a/types/universal.d.ts
+++ b/types/universal.d.ts
@@ -157,7 +157,7 @@ export interface TransitionProps<
    */
   from?: TFrom | ((item: TItem) => TFrom)
   /**
-   * Values that apply to new elements, or: fitem => values
+   * Values that apply to new elements, or: item => values
    * @default {}
    */
   enter?: TEnter | ((item: TItem) => TEnter)


### PR DESCRIPTION
Updating onDestroyed to reflect what it actually does on the implementation, maybe this should also be mentioned on the docs?

The first commit of this PR has a fix for typos, but I'm not 100% sure the naming was intentional or not. If it was, let me know and I'll revert the changes.