### PR TITLE
Fix native-hooks animated export

### DIFF
--- a/src/targets/native/hooks.js
+++ b/src/targets/native/hooks.js
@@ -30,7 +30,7 @@ Globals.injectCreateAnimatedStyle(styles =>
 
 export {
   config,
-  extendedAnimated as animated,
+  animated,
   interpolate,
   Globals,
   useSpring,


### PR DESCRIPTION
Fix `ReferenceError: extendedAnimated is not defined`