### PR TITLE
[react-native] Support nested array styles

### DIFF
--- a/src/shared/helpers.js
+++ b/src/shared/helpers.js
@@ -104,3 +104,15 @@ export function handleRef(ref, forward) {
   }
   return ref
 }
+
+export function flattenDeep(array) {
+  const items = toArray(array)
+
+  return items.reduce(
+    (result, item) =>
+      Array.isArray(item)
+        ? result.concat(flattenDeep(item))
+        : result.concat(item),
+    []
+  )
+}

--- a/src/targets/native/AnimatedStyles.js
+++ b/src/targets/native/AnimatedStyles.js
@@ -1,25 +1,36 @@
 import AnimatedWithChildren from '../../animated/AnimatedWithChildren'
 import AnimatedStyle from '../../animated/AnimatedStyle'
+import { flattenDeep } from '../../shared/helpers'
 
 export default class AnimatedStyles extends AnimatedWithChildren {
   constructor(styles) {
     super()
-    this.payload = styles.map(style => new AnimatedStyle(style))
+    this.payload = flattenDeep(styles).map(style =>
+      typeof style === 'number' ? style : new AnimatedStyle(style)
+    )
   }
 
   getValue() {
-    return this.payload.map(style => style.getValue())
+    return this.payload.map(style =>
+      typeof style === 'number' ? style : style.getValue()
+    )
   }
 
   getAnimatedValue() {
-    return this.payload.map(style => style.getAnimatedValue())
+    return this.payload
+      .filter(style => typeof style !== 'number')
+      .map(style => style.getAnimatedValue())
   }
 
   attach() {
-    this.payload.forEach(style => style.addChild(this))
+    this.payload
+      .filter(style => typeof style !== 'number')
+      .forEach(style => style.addChild(this))
   }
 
   detach() {
-    this.payload.forEach(style => style.removeChild(this))
+    this.payload
+      .filter(style => typeof style !== 'number')
+      .forEach(style => style.removeChild(this))
   }
 }

--- a/src/targets/native/hooks.js
+++ b/src/targets/native/hooks.js
@@ -24,9 +24,11 @@ Globals.injectApplyAnimatedValues(
     instance.setNativeProps ? instance.setNativeProps(props) : false,
   style => ({ ...style, transform: new AnimatedTransform(style.transform) })
 )
-Globals.injectCreateAnimatedStyle(styles =>
-  Array.isArray(styles) ? new AnimatedStyles(styles) : new AnimatedStyle(styles)
-)
+Globals.injectCreateAnimatedStyle(style => {
+  if (typeof style === 'number') return new AnimatedStyles([style])
+  if (Array.isArray(style)) return new AnimatedStyles(style)
+  return new AnimatedStyle(style)
+})
 
 export {
   config,

--- a/src/targets/native/index.js
+++ b/src/targets/native/index.js
@@ -22,9 +22,11 @@ Globals.injectApplyAnimatedValues(
     instance.setNativeProps ? instance.setNativeProps(props) : false,
   style => ({ ...style, transform: new AnimatedTransform(style.transform) })
 )
-Globals.injectCreateAnimatedStyle(styles =>
-  Array.isArray(styles) ? new AnimatedStyles(styles) : new AnimatedStyle(styles)
-)
+Globals.injectCreateAnimatedStyle(style => {
+  if (typeof style === 'number') return new AnimatedStyles([style])
+  if (Array.isArray(style)) return new AnimatedStyles(style)
+  return new AnimatedStyle(style)
+})
 
 export {
   Spring,


### PR DESCRIPTION
Fix #439
Fix #456

This also fixes `react-native-web` support.

> This is an alternative PR to #457. Check pros and cons below. Pick one.

### Demo

- https://codesandbox.io/s/jv55n5yyow
- https://snack.expo.io/@brunolemos/react-spring-styles-array

### Description

React Native not only supports `<View style=[{}, {}] />`, but also nested arrays like `<View style={[{}, [{}, [{}]]]} />`, this situation happens quite easily. 

`StyleSheet.flatten` exists to handle this, it merges all arrays into a single object. I used it on #457 as an alternative to this PR.

The problem with that approach it that it loses the optimization that `react-native-web` does. When doing `StyleSheet.create({ container: {} )`, the result will be `{ container: 1 }` on `react-native-web`, an int ID. _(`react-native` used to have this, but they removed it temporarily, may be added again in the future)._

### Pros compared to #457

- This PR preserves the stylesheet id optimization.

### Cons

- More verbose implementation. `this.payload` is now a mix of numbers and `AnimatedStyle` instances. 

_Not sure if this would break things in the future. This number check could be moved to another place as well, you know better where it should be._