### PR TITLE
Update Trail Props to allow for all spring props

### DIFF
--- a/types/universal.d.ts
+++ b/types/universal.d.ts
@@ -231,7 +231,7 @@ export class Transition<
 
 type TrailKeyProps = string | number
 
-interface TrailProps<TItem, DS extends object = {}> extends SpringBaseProps {
+interface TrailProps<TItem, DS extends object = {}> extends SpringProps {
   /**
    * Base values, optional
    */


### PR DESCRIPTION
Relevant to #386 

I believe Keyframes and Transition should also allow for `after` and other SpringProps, the Trail type was the most straight forward to fix though.

![trail props](https://user-images.githubusercontent.com/4078018/52136818-9bfda600-260e-11e9-8ff2-fbe0a7099211.png)

