### PR TITLE
Require `to` prop to correctly extend SpringProps

### DIFF
--- a/types/renderprops-universal.d.ts
+++ b/types/renderprops-universal.d.ts
@@ -239,7 +239,7 @@ interface TrailProps<TItem, DS extends object = {}> extends SpringProps {
   /**
    * Animates to ...
    */
-  to?: DS
+  to: DS
   /**
    * An array of items to be displayed, use this if you need access to the actual items when distributing values as functions
    */


### PR DESCRIPTION
When upgrading today, I got this error:

```
ERROR in [at-loader] ./node_modules/react-spring/renderprops-universal.d.ts:234:11 
    TS2430: Interface 'TrailProps<TItem, DS>' incorrectly extends interface 'SpringProps<{}>'.
  Property 'to' is optional in type 'TrailProps<TItem, DS>' but required in type 'SpringProps<{}>'.
```

I opened a PR to correct this error, but for unrelated reasons I was unable to confirm the fix in the project where I'm using react-spring. So I tried running tests and wasn't able to pass `yarn test` or `yarn test:ts`. 

Here are the TS errors for 8.0.1: 

```bash
brendan ~/P/t/react-spring> yarn test:ts
yarn run v1.13.0
$ tsc --noEmit
types/native-hooks.d.ts:1:15 - error TS2307: Cannot find module './hooks'.

1 export * from './hooks'
                ~~~~~~~~~

types/renderprops-konva.d.ts:6:24 - error TS2307: Cannot find module 'react-konva'.

6 import * as konva from 'react-konva'
                         ~~~~~~~~~~~~~

types/renderprops-konva.d.ts:14:5 - error TS2538: Type 'symbol' cannot be used as an index type.

14   }[keyof typeof konva]
       ~~~~~~~~~~~~~~~~~~

types/renderprops-konva.d.ts:20:29 - error TS2344: Type 'Pick<any, string>[Tag]' does not satisfy the constraint 'ReactType<any>'.
  Type 'Pick<any, string>[Tag]' is not assignable to type '"mpath"'.

20       ComponentPropsWithRef<KonvaComponents[Tag]>
                               ~~~~~~~~~~~~~~~~~~~~

types/renderprops-universal.d.ts:234:11 - error TS2430: Interface 'TrailProps<TItem, DS>' incorrectly extends interface 'SpringProps<{}>'.
  Types of property 'children' are incompatible.
    Type '((item: TItem, index: number) => SpringRendererFunc<DS>) | undefined' is not assignable to type 'SpringRendererFunc<{}> | undefined'.
      Type '(item: TItem, index: number) => SpringRendererFunc<DS>' is not assignable to type 'SpringRendererFunc<{}>'.

234 interface TrailProps<TItem, DS extends object = {}> extends SpringProps {
              ~~~~~~~~~~


Found 5 errors.

```

After my one-character fix, the last error is replaced with this:

```bash
types/renderprops-universal.d.ts:234:11 - error TS2430: Interface 'TrailProps<TItem, DS>' incorrectly extends interface 'SpringProps<{}>'.
  Types of property 'children' are incompatible.
    Type '((item: TItem, index: number) => SpringRendererFunc<DS>) | undefined' is not assignable to type 'SpringRendererFunc<{}> | undefined'.
      Type '(item: TItem, index: number) => SpringRendererFunc<DS>' is not assignable to type 'SpringRendererFunc<{}>'.

234 interface TrailProps<TItem, DS extends object = {}> extends SpringProps {
              ~~~~~~~~~~

```

Wasn't sure how to fix that. I did notice that [this commit](https://github.com/react-spring/react-spring/commit/6ce0934928febd5f3bef866a50897bbbfffd1294) seems to be the what broke the types for this interface.

Hope I helped a bit!