### PR TITLE
Fix TrailProps interface incorrectly extends SpringProps

### DIFF
--- a/types/renderprops-universal.d.ts
+++ b/types/renderprops-universal.d.ts
@@ -74,7 +74,7 @@ export interface SpringProps<DS extends object = {}> extends SpringBaseProps {
    * Animates to...
    * @default {}
    */
-  to: DS
+  to?: DS
   /**
    * Callback when the animation comes to a still-stand
    */
@@ -231,7 +231,13 @@ export class Transition<
 
 type TrailKeyProps = string | number
 
-interface TrailProps<TItem, DS extends object = {}> extends SpringProps {
+/**
+ * Relay interface to override inheritance property
+ */
+interface TrailPropsWeaken extends SpringProps {
+  children?: any
+}
+interface TrailProps<TItem, DS extends object = {}> extends TrailPropsWeaken {
   /**
    * Base values, optional
    */
@@ -239,7 +245,7 @@ interface TrailProps<TItem, DS extends object = {}> extends SpringProps {
   /**
    * Animates to ...
    */
-  to: DS
+  to?: DS
   /**
    * An array of items to be displayed, use this if you need access to the actual items when distributing values as functions
    */
@@ -252,7 +258,7 @@ interface TrailProps<TItem, DS extends object = {}> extends SpringProps {
   /**
    * A single function-child that receives the individual item and return a functional component (item, index) => props => view)
    */
-  children?: (item: TItem, index: number) => SpringRendererFunc<DS>
+  children: (item: TItem, index: number) => SpringRendererFunc<DS>
 }
 
 export class Trail<TItem, DS extends object> extends PureComponent<


### PR DESCRIPTION
## Fix for this type error

```bash
node_modules/react-spring/renderprops-universal.d.ts:234:11 - error TS2430: 
Interface 'TrailProps<TItem, DS>' incorrectly extends interface 'SpringProps<{}>'.
  Types of property 'to' are incompatible.
    Type 'DS | undefined' is not assignable to type '{}'.
      Type 'undefined' is not assignable to type '{}'.

234 interface TrailProps<TItem, DS extends object = {}> extends SpringProps {
              ~~~~~~~~~~
```

---

## This PR is re-fix of @BrendanBerkley 's PR #496

and related PR #481.

@BrendanBerkley says

> Error 5 is what my one-character PR attempted to fix, and my other code snippet is the new error that happens once I did so. There's a type mismatch with `children`, and I don't know how to fix that.

As far as read the document, `to` props should not be required in the first place. (https://react-spring-renderprops.surge.sh/spring#props) 🤔 

So, it is a way to override part of the inheritance interface property, but TS can't do it now. However, it can be realized by changing the property once to any as a relay type.

(cf. https://github.com/Microsoft/TypeScript/issues/3402)

How about thinking that this PR is as expected by everyone?