### PR TITLE
fix useTransition keys type

### DIFF
--- a/types/web.d.ts
+++ b/types/web.d.ts
@@ -213,7 +213,8 @@ export function useTransition<TItem, DS extends CSSProperties>(
   keys:
     | ((item: TItem) => TransitionKeyProps)
     | ReadonlyArray<TransitionKeyProps>
-    | TransitionKeyProps,
+    | TransitionKeyProps
+    | null,
   values: Merge<DS & CSSProperties, UseTransitionProps<TItem, DS>>
 ): UseTransitionResult<TItem, ForwardedProps<DS>>[] // result array is safe to modify
 export function useTransition<TItem, DS extends object>(
@@ -221,6 +222,7 @@ export function useTransition<TItem, DS extends object>(
   keys:
     | ((item: TItem) => TransitionKeyProps)
     | ReadonlyArray<TransitionKeyProps>
-    | TransitionKeyProps,
+    | TransitionKeyProps           
+    | null,
   values: Merge<DS, UseTransitionProps<TItem, DS>>
 ): UseTransitionResult<TItem, AnimatedValue<ForwardedProps<DS>>>[] // result array is safe to modify


### PR DESCRIPTION
```
Argument of type 'null' is not assignable to parameter of type 'string | number | ReadonlyArray<string | number> | ((item: boolean) => string | number)'.
```

https://github.com/react-spring/react-spring/issues/495#issuecomment-461192304
