### PR TITLE
ExcludedProps update to reflect actual implementation

### DIFF
--- a/types/web.d.ts
+++ b/types/web.d.ts
@@ -16,7 +16,6 @@ type ExcludedProps =
   | 'to'
   | 'from'
   | 'config'
-  | 'native'
   | 'onStart'
   | 'onRest'
   | 'onFrame'
@@ -25,15 +24,12 @@ type ExcludedProps =
   | 'reverse'
   | 'force'
   | 'immediate'
-  | 'impl'
-  | 'inject'
   | 'delay'
   | 'attach'
   | 'destroyed'
-  | 'track'
   | 'interpolateTo'
-  | 'autoStart'
   | 'ref'
+  | 'lazy'
 
 // The config options for an interoplation. It maps out from in "in" type
 // to an "out" type.


### PR DESCRIPTION
Doing this one because I was checking the `getForwardProps` function from helpers.ts and having some problems to type it when I realized it was just because I was using this list for the types when the actual implementation was different.