### PR TITLE
Fix ordering of deleted items

### DIFF
--- a/src/useTransition.js
+++ b/src/useTransition.js
@@ -213,7 +213,7 @@ function diffItems({ first, prevProps, ...state }, props) {
           const keyIndex = _keys.indexOf(key)
           const item = _items[keyIndex]
           const slot = LEAVE
-          deleted.unshift({
+          deleted.push({
             ...current[key],
             slot,
             destroyed: true,


### PR DESCRIPTION
Fixes: https://github.com/react-spring/react-spring/issues/461

The logic recreating the ordering of the items requires the deleted items to have consistent ordering. This seems to be already fixed in Transition.js.

Btw there seems to be other differences between Transition.js and useTransition.js even though they probably should be deduplicated.