### PR TITLE
V9: Add null as an option for Transition#initial

### DIFF
--- a/types/lib/useTransition.d.ts
+++ b/types/lib/useTransition.d.ts
@@ -66,7 +66,7 @@ export type UseTransitionProps<Item = any> = {
   /**
    * First-render initial values, if present overrides "from" on the first render pass. It can be "null" to skip first mounting transition. Otherwise it can take an object or a function (item => object)
    */
-  initial?: TransitionProp<Item>
+  initial?: TransitionProp<Item> | null
   /**
    * Configure the spring behavior for each item.
    */


### PR DESCRIPTION
The docs say you can pass `null` to `initial`, but the types don't allow it.