### PR TITLE
v9: Fix TS

### DIFF
--- a/types/lib/interpolation.d.ts
+++ b/types/lib/interpolation.d.ts
@@ -1,5 +1,5 @@
 import { Animatable, SpringValue, RawValues } from './animated'
-import { Arrify } from './common'
+import { Arrify, OneOrMore } from './common'
 
 export type EasingFunction = (t: number) => number
 
@@ -60,7 +60,7 @@ export interface Interpolator<In = any> {
   ): SpringValue<Animatable<Out>>
 
   <Out extends Animatable = Animatable>(
-    config: InterpolatorConfig<Out> | InterpolatorFn<In, Out>
+    config: InterpolatorConfig<Out> | InterpolatorFn<Arrify<In>, Out>
   ): SpringValue<Animatable<Out>>
 }
 

--- a/types/web.d.ts
+++ b/types/web.d.ts
@@ -1,4 +1,5 @@
-import { SpringValue, Solve, AssignableKeys } from './lib/common'
+import { Solve, AssignableKeys } from './lib/common'
+import { SpringValue } from './lib/animated'
 import {
   ElementType,
   CSSProperties,


### PR DESCRIPTION
I'm seeing the same compiler errors as https://github.com/react-spring/react-spring/issues/642#issuecomment-491309508 on `react-spring@9.0.0-beta.8`. I think my proposed changes fixes things; basically just fixed import paths and mimicked other, working type defs.

Here's how I went about testing my changes:

1. Clone this branch.
2. `yarn build`
3. Publish locally with [yalc](https://github.com/whitecolor/yalc)
4. Add locally-published `react-spring` to my project.
5. Build my project: build errors vanished.

I noticed [CI is currently failing on v9](https://github.com/react-spring/react-spring/issues/642#issuecomment-491309508) for the same reasons my PR is, so I don't think this change broke anything.