### PR TITLE
Extend HooksBaseProps from SpringProps

### DIFF
--- a/types/web.d.ts
+++ b/types/web.d.ts
@@ -2,6 +2,7 @@ import { CSSProperties, RefObject } from 'react'
 import {
   SpringConfig,
   SpringBaseProps,
+  SpringProps,
   TransitionKeyProps,
   State,
 } from './renderprops-universal'
@@ -95,7 +96,7 @@ export function useChain(
 ): void
 
 export interface HooksBaseProps
-  extends Pick<SpringBaseProps, Exclude<keyof SpringBaseProps, 'config'>> {
+  extends Pick<SpringProps, Exclude<keyof SpringProps, 'config'>> {
   /**
    * Will skip rendering the component if true and write to the dom directly.
    * @default true


### PR DESCRIPTION
Currently, the typings for useTransition cause an error when declaring `onRest` and `onFrame`. This seems to be caused by a chain dependencies that result in:

```typescript
export interface HooksBaseProps extends Pick<SpringBaseProps, Exclude<keyof SpringBaseProps, 'config'>> {
```

SpringBaseProps looks like:
```typescript
export interface SpringBaseProps {
  config?: SpringConfig | ((key: string) => SpringConfig)
  native?: boolean
  reset?: boolean
  immediate?: boolean | ((key: string) => boolean)
  delay?: number
  reverse?: boolean
  onStart?(): void
}
```

The SpringProps interface declares the missing props and extends SpringBaseProps, so I think the solution is for HooksBaseProps to extend SpringProps instead of SpringBaseProps directly.
