### PR TITLE
FIX: types ParallaxLayer and Parallax props to real implementation and opportunities

### DIFF
--- a/types/renderprops-addons.d.ts
+++ b/types/renderprops-addons.d.ts
@@ -1,7 +1,7 @@
 import { Ref, PureComponent } from 'react'
 import { SpringConfig } from './renderprops-universal'
 
-interface ParallaxProps {
+interface ParallaxProps extends React.HTMLAttributes<HTMLElement> {
   pages: number
 
   config?: SpringConfig | ((key: string) => SpringConfig)
@@ -17,7 +17,7 @@ export class Parallax extends PureComponent<ParallaxProps> {
   scrollTo: (offset: number) => void
 }
 
-interface ParallaxLayerProps {
+interface ParallaxLayerProps extends React.HTMLAttributes<HTMLDivElement> {
   factor?: number
 
   offset?: number


### PR DESCRIPTION
Adding correct type definition to props signature of real implementation of Parallax and ParallaxLayer exported classes. Support for props translated to native elements 'as is'