### PR TITLE
Better inheritance of config properties and callbacks

### DIFF
--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -56,6 +56,7 @@ function getForwardProps<Props extends ReservedProps>(
     onDestroyed,
     timestamp,
     attach,
+    async,
     ...forward
   } = props
   return forward

--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -104,4 +104,5 @@ export interface ReservedProps {
   onDestroyed?: any
   timestamp?: any
   attach?: any
+  async?: boolean
 }


### PR DESCRIPTION
## Feature proposal

Better inheritance of controller config properties following the logic below:

- Properties defined in the initial `useSpring` call should be extended on subsequent  `set` calls. 
- Properties defined in a `set` call should override initial properties for that call only (ie a second `set` call shouldn’t inherit properties defined in the first one).
- In async runs, `next` calls should inherit properties from the outer `set`, with the exception of `onAnimated` which should be called once at the beginning of the animation, and `onRest` which should be called once at the end of the animation. However, defining `onFrame` in set would apply to all inner `next` runs.
- Similarly, consecutive `next` runs shouldn’t inherit properties from each other.

### Example

```jsx
console.log('executing initial spring call')

const [props, set, stop] = useSpring(() => ({
  y: 0,
  x: 0,
  onRest: () => console.log('onRest initial'),
}))

React.useEffect(() => {
  console.log('executing set call')

  set({
    config: config.wobbly,

    // should execute only once
    onAnimate: v => console.log('[set] onAnimate'),

    // should execute on each frame
    onFrame: v => console.log('[set] onFrame'),

    // should execute only once, will override initial onRest
    onRest: v => console.log('[set] onRest'),
    to: async next => {
      console.log('executing first next call')

      await next({
        y: 200,

        // config will be stiff when animating `y`
        config: config.stiff,

        // should override onFrame defined in above
        onFrame: v => console.log('[next] onFrame'),
      })

      console.log('executing second next call')
      // should execute onFrame function defined in the `set` call
      // should apply config.wobbly when animating `x`
      await next({ x: 300 })
    },
  })
})
```

#### Output

The console should output the following logs:

![options](https://user-images.githubusercontent.com/5003380/63692878-f8c2e700-c812-11e9-8244-0182ce81d2cb.png)

### Disclaimer

This is a very naive implementation and should probably be reworked.
