### PR TITLE
fix: transformOrigin and transformStyle are correctly passed as CSS props

### DIFF
--- a/targets/web/src/AnimatedStyle.ts
+++ b/targets/web/src/AnimatedStyle.ts
@@ -15,14 +15,7 @@ import {
  * animated. Perspective has been left out as it would conflict with the
  * non-transform perspective style.
  */
-const domTransforms = [
-  'transform',
-  'matrix',
-  'translate',
-  'scale',
-  'rotate',
-  'skew',
-]
+const domTransforms = ['matrix', 'translate', 'scale', 'rotate', 'skew']
 
 // x, y, z and translate will get 'px' as unit default
 const pxDefaults = ['x', 'y', 'z', 'translate']
@@ -139,17 +132,18 @@ export class AnimatedStyle extends AnimatedObject {
       ])
     }
 
-    // then for each style key that matches the transform functions class
-    // supports, we add the input value to the props and the interpolation
-    // transform function
+    // then for each style key that matches the supported transform functions,
+    // we add the input value to the props and the interpolation transform
+    // function
     each(style, (value, key) => {
-      if (domTransforms.some(transform => key.startsWith(transform))) {
+      if (key === 'transform') {
+        props.push(ensureAnimated(value))
+        transforms.push((transform: string) => [transform, transform === ''])
+      } else if (domTransforms.some(transform => key.startsWith(transform))) {
         const unit = getUnit(key)
         props.push(ensureAnimated(value))
         transforms.push(
-          key === 'transform'
-            ? (transform: string) => [transform, transform === '']
-            : key === 'rotate3d'
+          key === 'rotate3d'
             ? ([x, y, z, deg]) => [
                 `rotate3d(${x},${y},${z},${mergeUnit(deg, unit)})`,
                 isTransformIdentity(key, deg),

--- a/targets/web/src/animated.test.tsx
+++ b/targets/web/src/animated.test.tsx
@@ -179,6 +179,7 @@ describe('animated component', () => {
           z,
           scale: 1,
           skewX: 0,
+          transformOrigin: 'bottom center',
           rotate3d: [1, 0, 0, '0deg'],
         }}
         data-testid="wrapper"
@@ -186,5 +187,23 @@ describe('animated component', () => {
     )
     const wrapper: any = queryByTestId('wrapper')!
     expect(wrapper.style.transform).toBe('none')
+  })
+
+  it('preserves transform-style and transform-origin properties', () => {
+    const { queryByTestId } = render(
+      <a.div
+        style={{
+          transformOrigin: 'bottom center',
+          transformStyle: 'preserve-3d',
+          transform: 'translateX(40px)',
+          scale: [1, 2],
+        }}
+        data-testid="wrapper"
+      />
+    )
+    const wrapper: any = queryByTestId('wrapper')!
+    expect(wrapper.style.transformOrigin).toBe('bottom center')
+    expect(wrapper.style.transformStyle).toBe('preserve-3d')
+    expect(wrapper.style.transform).toBe('translateX(40px) scale(1,2)')
   })
 })


### PR DESCRIPTION
Fixes this: https://github.com/react-spring/react-spring/pull/782#issuecomment-526255242