### PR TITLE
Call rAF with window/global scope

### DIFF
--- a/packages/addons/src/parallax.tsx
+++ b/packages/addons/src/parallax.tsx
@@ -238,7 +238,7 @@ export const Parallax = React.memo(
       if (!state.busy) {
         state.busy = true
         state.current = event.target[getScrollType(horizontal)]
-        requestAnimationFrame(() => {
+        requestAnimationFrame.call(window, () => {
           state.layers.forEach(layer =>
             layer.setPosition(state.space, state.current)
           )
@@ -253,7 +253,7 @@ export const Parallax = React.memo(
 
       const onResize = () => {
         const update = () => state.update()
-        requestAnimationFrame(update)
+        requestAnimationFrame.call(window, update)
         setTimeout(update, 150) // Some browsers don't fire on maximize!
       }
 


### PR DESCRIPTION
Chrome seems to break when invoking rAF stored as a referenced property of a different object other than the global scope.

For example: https://stackoverflow.com/questions/9677985/uncaught-typeerror-illegal-invocation-in-chrome

Error is below:

```
parallax.cjs.js:195 Uncaught TypeError: Illegal invocation
    at onScroll (parallax.cjs.js:195)
    at HTMLUnknownElement.callCallback (react-dom.development.js:348)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:398)
    at invokeGuardedCallback (react-dom.development.js:455)
    at invokeGuardedCallbackAndCatchFirstError (react-dom.development.js:469)
    at executeDispatch (react-dom.development.js:601)
    at executeDispatchesInOrder (react-dom.development.js:623)
    at executeDispatchesAndRelease (react-dom.development.js:726)
    at executeDispatchesAndReleaseTopLevel (react-dom.development.js:734)
    at forEachAccumulated (react-dom.development.js:708)
```

```
  var onScroll = function onScroll(event) {
    if (!state.busy) {
      state.busy = true;
      state.current = event.target[getScrollType(horizontal)];
      globals.requestAnimationFrame(function () {    // <--- Should be invoked with `window` scope
        state.layers.forEach(function (layer) {
          return layer.setPosition(state.space, state.current);
        });
        state.busy = false;
      });
    }
  };
```

CC: @aleclarson 