### PR TITLE
Use Array.from project param instead of map

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -19,16 +19,16 @@
     "gzipped": 1999
   },
   "dist/web.js": {
-    "bundled": 63554,
-    "minified": 30170,
-    "gzipped": 10988,
+    "bundled": 63611,
+    "minified": 30144,
+    "gzipped": 10976,
     "treeshaked": {
       "rollup": {
-        "code": 11571,
+        "code": 11548,
         "import_statements": 242
       },
       "webpack": {
-        "code": 12733
+        "code": 12710
       }
     }
   },
@@ -38,44 +38,44 @@
     "gzipped": 11641
   },
   "dist/native.js": {
-    "bundled": 60686,
-    "minified": 28249,
-    "gzipped": 10010,
+    "bundled": 60743,
+    "minified": 28223,
+    "gzipped": 9998,
     "treeshaked": {
       "rollup": {
         "code": 8256,
         "import_statements": 180
       },
       "webpack": {
-        "code": 10881
+        "code": 10858
       }
     }
   },
   "dist/universal.js": {
-    "bundled": 48123,
-    "minified": 21539,
-    "gzipped": 7195,
+    "bundled": 48180,
+    "minified": 21513,
+    "gzipped": 7188,
     "treeshaked": {
       "rollup": {
         "code": 1235,
         "import_statements": 128
       },
       "webpack": {
-        "code": 4733
+        "code": 4710
       }
     }
   },
   "dist/konva.js": {
-    "bundled": 59176,
-    "minified": 27394,
-    "gzipped": 9921,
+    "bundled": 59233,
+    "minified": 27368,
+    "gzipped": 9908,
     "treeshaked": {
       "rollup": {
-        "code": 9090,
+        "code": 9067,
         "import_statements": 242
       },
       "webpack": {
-        "code": 10246
+        "code": 10223
       }
     }
   },
@@ -157,14 +157,14 @@
     "gzipped": 9928
   },
   "dist/web.cjs.js": {
-    "bundled": 71882,
-    "minified": 33885,
-    "gzipped": 11553
+    "bundled": 71939,
+    "minified": 33847,
+    "gzipped": 11537
   },
   "dist/native.cjs.js": {
-    "bundled": 69495,
-    "minified": 32150,
-    "gzipped": 10560
+    "bundled": 69552,
+    "minified": 32112,
+    "gzipped": 10544
   },
   "dist/renderprops.cjs.js": {
     "bundled": 77392,
@@ -192,9 +192,9 @@
     "gzipped": 10442
   },
   "dist/universal.cjs.js": {
-    "bundled": 56122,
-    "minified": 25121,
-    "gzipped": 7750
+    "bundled": 56179,
+    "minified": 25083,
+    "gzipped": 7735
   },
   "dist/test.js": {
     "bundled": 32365,
@@ -216,46 +216,46 @@
     "gzipped": 5405
   },
   "dist/konva.cjs.js": {
-    "bundled": 67216,
-    "minified": 31007,
-    "gzipped": 10463
+    "bundled": 67273,
+    "minified": 30969,
+    "gzipped": 10448
   },
   "dist/three.js": {
-    "bundled": 59525,
-    "minified": 27361,
-    "gzipped": 9830,
+    "bundled": 59582,
+    "minified": 27335,
+    "gzipped": 9820,
     "treeshaked": {
       "rollup": {
-        "code": 10499,
+        "code": 10476,
         "import_statements": 344
       },
       "webpack": {
-        "code": 11711
+        "code": 11688
       }
     }
   },
   "dist/three.cjs.js": {
-    "bundled": 67628,
-    "minified": 31022,
-    "gzipped": 10369
+    "bundled": 67685,
+    "minified": 30984,
+    "gzipped": 10350
   },
   "dist/zdog.js": {
-    "bundled": 60089,
-    "minified": 27582,
-    "gzipped": 9886,
+    "bundled": 60146,
+    "minified": 27556,
+    "gzipped": 9875,
     "treeshaked": {
       "rollup": {
-        "code": 10633,
+        "code": 10610,
         "import_statements": 354
       },
       "webpack": {
-        "code": 11762
+        "code": 11739
       }
     }
   },
   "dist/zdog.cjs.js": {
-    "bundled": 68132,
-    "minified": 31183,
-    "gzipped": 10438
+    "bundled": 68189,
+    "minified": 31145,
+    "gzipped": 10418
   }
 }

--- a/src/useTransition.js
+++ b/src/useTransition.js
@@ -64,14 +64,15 @@ export function useTransition(input, keyTransform, config) {
   useImperativeHandle(props.ref, () => ({
     start: () =>
       Promise.all(
-        Array.from(state.current.instances).map(
+        Array.from(
+          state.current.instances,
           ([, c]) => new Promise(r => c.start(r))
         )
       ),
     stop: finished =>
-      Array.from(state.current.instances).forEach(([, c]) => c.stop(finished)),
+      void Array.from(state.current.instances, ([, c]) => c.stop(finished)),
     get controllers() {
-      return Array.from(state.current.instances).map(([, c]) => c)
+      return Array.from(state.current.instances, ([, c]) => c)
     },
   }))
 
@@ -124,7 +125,7 @@ export function useTransition(input, keyTransform, config) {
     state.current.mounted = mounted.current = true
     return () => {
       state.current.mounted = mounted.current = false
-      Array.from(state.current.instances).map(([, c]) => c.destroy())
+      Array.from(state.current.instances, ([, c]) => c.destroy())
       state.current.instances.clear()
     }
   }, [])


### PR DESCRIPTION
This is a microoptimization in file size and runtime. `Array.from()` supports a project argument as the second parameter to map each value, therefore it is not necessary to use `.map()` right afterwards.

Feel free to close if you think this might hurt expliciteness or readability.