### PR TITLE
 Use Array.from project param instead of map

### DIFF
--- a/packages/core/src/Controller.ts
+++ b/packages/core/src/Controller.ts
@@ -753,7 +753,7 @@ function createAnimated<T>(
  * This is most useful for async updates, which don't cause a re-render.
  */
 function moveChildren(prev: Animated, next: Animated) {
-  each(Array.from(prev.getChildren()), child => {
+  Array.from(prev.getChildren(), child => {
     child.updatePayload(prev, next)
     prev.removeChild(child)
     next.addChild(child)

--- a/packages/core/src/useTransition.js
+++ b/packages/core/src/useTransition.js
@@ -64,14 +64,15 @@ export function useTransition(input, keyTransform, props) {
   useImperativeHandle(ref, () => ({
     start: () =>
       Promise.all(
-        Array.from(state.current.instances).map(
+        Array.from(
+          state.current.instances,
           ([, c]) => new Promise(r => c.start(r))
         )
       ),
     stop: finished =>
-      Array.from(state.current.instances).forEach(([, c]) => c.stop(finished)),
+      void Array.from(state.current.instances, ([, c]) => c.stop(finished)),
     get controllers() {
-      return Array.from(state.current.instances).map(([, c]) => c)
+      return Array.from(state.current.instances, ([, c]) => c)
     },
   }))
 
@@ -128,7 +129,7 @@ export function useTransition(input, keyTransform, props) {
     state.current.mounted = mounted.current = true
     return () => {
       state.current.mounted = mounted.current = false
-      Array.from(state.current.instances).map(([, c]) => c.destroy())
+      Array.from(state.current.instances, ([, c]) => c.destroy())
       state.current.instances.clear()
     }
   })


### PR DESCRIPTION
Originally https://github.com/react-spring/react-spring/pull/823 but for `v9`.

This is a microoptimization in file size and runtime. `Array.from()` supports a project argument as the second parameter to map each value, therefore it is not necessary to use `.map()` right afterwards.

Feel free to close if you think this might hurt expliciteness or readability.