### PR TITLE
Incorrect return value from useSpring using deps

### DIFF
--- a/packages/core/src/useSpring.ts
+++ b/packages/core/src/useSpring.ts
@@ -64,5 +64,5 @@ export function useSpring<Props extends UnknownProps>(
 export function useSpring(props: any, deps?: any[]): any {
   const isFn = is.fun(props)
   const [[values], update, stop] = useSprings(1, isFn ? props : [props], deps)
-  return isFn || arguments.length == 3 ? [values, update, stop] : values
+  return isFn || arguments.length == 2 ? [values, update, stop] : values
 }


### PR DESCRIPTION
Should be 2 for testing `arguments.length` in `useSpring(props, deps)`.