### PR TITLE
useTransition: Fix deleted items handing

### DIFF
--- a/src/useTransition.js
+++ b/src/useTransition.js
@@ -217,8 +217,6 @@ function diffItems({ first, prevProps, ...state }, props) {
             ...current[key],
             slot,
             destroyed: true,
-            left: _keys[Math.max(0, keyIndex - 1)],
-            right: _keys[Math.min(_keys.length, keyIndex + 1)],
             trail: (delay = delay + trail),
             config: callProp(config, item, slot),
             to: callProp(leave, item),
@@ -245,17 +243,9 @@ function diffItems({ first, prevProps, ...state }, props) {
       }
     }
   }
-  let out = keys.map(key => current[key])
-
-  // This tries to restore order for deleted items by finding their last known siblings
-  // only using the left sibling to keep order placement consistent for all deleted items
-  deleted.forEach(({ left, right, ...item }) => {
-    let pos
-    // Was it the element on the left, if yes, move there ...
-    if ((pos = out.findIndex(t => t.originalKey === left)) !== -1) pos += 1
-    // And if nothing else helps, move it to the start ¯\_(ツ)_/¯
-    pos = Math.max(0, pos)
-    out = [...out.slice(0, pos), item, ...out.slice(pos)]
+  let out = [...keys.map(key => current[key]), ...deleted]
+  out.sort((a, b) => {
+    return _keys.indexOf(a.originalKey) - _keys.indexOf(b.originalKey)
   })
 
   return {


### PR DESCRIPTION
I am bumping up against this line https://github.com/react-spring/react-spring/blob/66087e18b64d6c6d5fd75f6d84e85ed59714769d/src/useTransition.js#L256. I have a list of items, and when consecutive items are removed from the list, this line of code causes all items that had their previous sibling removed to jump to the top of the list. For example:

![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/218725/68437359-b280f100-018e-11ea-88ec-92a981df919a.gif)

This can get really jarring if lots of items are moved to the top. 

This PR simplifies the behavior by sorting the resulting list relative to the previous list. References to `left` and `right` are removed. `right` was not being used already, and left is `left` is removed due to this PR.

After this PR:

![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/218725/68437614-79954c00-018f-11ea-9d55-f4c8ed423166.gif)
