### PR TITLE
Update formula for frequency response

### DIFF
--- a/packages/core/src/Animation.test.ts
+++ b/packages/core/src/Animation.test.ts
@@ -1,0 +1,19 @@
+import { AnimationConfig } from './Animation'
+
+const config = new AnimationConfig()
+
+describe('AnimationConfig', () => {
+  describe('merge', () => {
+    it('should convert frequency and damping vars to appropriate tension and friction ', () => {
+      config.merge({ mass: 1, frequency: 0.5, damping: 1 })
+      expect(config.tension).toBe(157.91367041742973)
+      expect(config.friction).toBe(25.132741228718345)
+    })
+
+    it('should still work with extreme but valid values', () => {
+      config.merge({ mass: 1, frequency: 2.6, damping: 0.1 })
+      expect(config.tension).toBe(5.840002604194885)
+      expect(config.friction).toBe(0.483321946706122)
+    })
+  })
+})

--- a/packages/core/src/Animation.test.ts
+++ b/packages/core/src/Animation.test.ts
@@ -1,19 +1,38 @@
 import { AnimationConfig } from './Animation'
 
-const config = new AnimationConfig()
-
 describe('AnimationConfig', () => {
   describe('merge', () => {
     it('should convert frequency and damping vars to appropriate tension and friction ', () => {
-      config.merge({ mass: 1, frequency: 0.5, damping: 1 })
+      const config = new AnimationConfig()
+      config.merge({ frequency: 0.5, damping: 1 })
       expect(config.tension).toBe(157.91367041742973)
       expect(config.friction).toBe(25.132741228718345)
     })
 
     it('should still work with extreme but valid values', () => {
-      config.merge({ mass: 1, frequency: 2.6, damping: 0.1 })
+      const config = new AnimationConfig()
+      config.merge({ frequency: 2.6, damping: 0.1 })
       expect(config.tension).toBe(5.840002604194885)
       expect(config.friction).toBe(0.483321946706122)
+    })
+    it('should guard against a damping ratio that is less than 0', () => {
+      const invalidConfig = new AnimationConfig()
+      invalidConfig.merge({ frequency: 0.5, damping: -1 })
+      const validConfig = new AnimationConfig()
+      validConfig.merge({ frequency: 0.5, damping: 0 })
+
+      expect(invalidConfig.tension).toBe(validConfig.tension)
+      expect(invalidConfig.friction).toBe(validConfig.friction)
+    })
+
+    it('should guard against a frequency response that is less than or equal to 0', () => {
+      const invalidConfig = new AnimationConfig()
+      invalidConfig.merge({ frequency: 0, damping: 1 })
+      const validConfig = new AnimationConfig()
+      validConfig.merge({ frequency: 0.01, damping: 1 })
+
+      expect(invalidConfig.tension).toBe(validConfig.tension)
+      expect(invalidConfig.friction).toBe(validConfig.friction)
     })
   })
 })

--- a/packages/core/src/Animation.ts
+++ b/packages/core/src/Animation.ts
@@ -168,8 +168,10 @@ export class AnimationConfig {
 
     // Derive "tension" and "friction" from "frequency" and "damping".
     if (!is.und(frequency)) {
-      this.tension = Math.pow((2 * Math.PI) / frequency, 2) * mass
-      this.friction = (4 * Math.PI * damping * mass) / frequency
+      const guardedFrequency = frequency <= 0 ? 0.01 : frequency
+      const guardedDamping = damping < 0 ? 0 : damping
+      this.tension = Math.pow((2 * Math.PI) / guardedFrequency, 2) * mass
+      this.friction = (4 * Math.PI * guardedDamping * mass) / guardedFrequency
     }
 
     /* might be reintroduced later */

--- a/packages/core/src/Animation.ts
+++ b/packages/core/src/Animation.ts
@@ -168,8 +168,8 @@ export class AnimationConfig {
 
     // Derive "tension" and "friction" from "frequency" and "damping".
     if (!is.und(frequency)) {
-      this.tension = Math.pow(frequency, 2) * mass
-      this.friction = (damping * Math.sqrt(this.tension * mass)) / 0.5
+      this.tension = Math.pow((2 * Math.PI) / frequency, 2) * mass
+      this.friction = (4 * Math.PI * damping * mass) / frequency
     }
 
     /* might be reintroduced later */


### PR DESCRIPTION
Hi, this is using the formula I found [in this article](https://medium.com/ios-os-x-development/demystifying-uikit-spring-animations-2bb868446773), which seems consistent with  [apple's guidelines](https://developer.apple.com/videos/play/wwdc2018/803/?time=2117). I used it to make [this interactive demo](https://spring-playground.netlify.com/). 

I wasn't sure whether to add more logic around guarding against invalid values, please let me know if that would be preferred.

(This pr was made in response to [this comment by @aleclarson](https://github.com/react-spring/react-use-gesture/issues/109#issuecomment-554409570).)