### PR TITLE
Backport skipAnimation global

### DIFF
--- a/src/animated/Controller.ts
+++ b/src/animated/Controller.ts
@@ -12,7 +12,7 @@ import {
   colorNames,
   interpolation as interp,
   now,
-  forceImmediate,
+  skipAnimation,
 } from './Globals'
 
 type FinishedCallback = (finished?: boolean) => void
@@ -210,7 +210,7 @@ class Controller<P extends any = {}> {
       ;[from, to] = [to, from]
     }
 
-    if (forceImmediate) {
+    if (skipAnimation) {
       immediate = true
     }
 

--- a/src/animated/Controller.ts
+++ b/src/animated/Controller.ts
@@ -8,7 +8,12 @@ import {
 import AnimatedValue from './AnimatedValue'
 import AnimatedValueArray from './AnimatedValueArray'
 import { start, stop } from './FrameLoop'
-import { colorNames, interpolation as interp, now } from './Globals'
+import {
+  colorNames,
+  interpolation as interp,
+  now,
+  forceImmediate,
+} from './Globals'
 
 type FinishedCallback = (finished?: boolean) => void
 
@@ -203,6 +208,10 @@ class Controller<P extends any = {}> {
     // Reverse values when requested
     if (reverse) {
       ;[from, to] = [to, from]
+    }
+
+    if (forceImmediate) {
+      immediate = true
     }
 
     // This will collect all props that were ever set, reset merged props when necessary

--- a/src/animated/Globals.ts
+++ b/src/animated/Globals.ts
@@ -73,3 +73,8 @@ export let manualFrameloop: any
 export function injectManualFrameloop(callback: any) {
   manualFrameloop = callback
 }
+
+export let forceImmediate = false
+export function injectForceImmediate(skip: boolean) {
+  forceImmediate = skip
+}

--- a/src/animated/Globals.ts
+++ b/src/animated/Globals.ts
@@ -74,7 +74,7 @@ export function injectManualFrameloop(callback: any) {
   manualFrameloop = callback
 }
 
-export let forceImmediate = false
-export function injectForceImmediate(skip: boolean) {
-  forceImmediate = skip
+export let skipAnimation = false
+export function injectSkipAnimation(skip: boolean) {
+  skipAnimation = skip
 }

--- a/src/renderprops/animated/Controller.js
+++ b/src/renderprops/animated/Controller.js
@@ -1,7 +1,7 @@
 import Animated from './Animated'
 import AnimatedValue from './AnimatedValue'
 import AnimatedArray from './AnimatedArray'
-import { now, colorNames } from './Globals'
+import { now, colorNames, forceImmediate } from './Globals'
 import { addController, removeController } from './FrameLoop'
 import {
   interpolateTo,
@@ -51,6 +51,11 @@ export default class Controller {
     if (reverse) {
       ;[from, to] = [to, from]
     }
+
+    if (forceImmediate) {
+      immediate = true
+    }
+
     this.hasChanged = false
     // Attachment handling, trailed springs can "attach" themselves to a previous spring
     let target = attach && attach(this)

--- a/src/renderprops/animated/Controller.js
+++ b/src/renderprops/animated/Controller.js
@@ -1,7 +1,7 @@
 import Animated from './Animated'
 import AnimatedValue from './AnimatedValue'
 import AnimatedArray from './AnimatedArray'
-import { now, colorNames, forceImmediate } from './Globals'
+import { now, colorNames, skipAnimation } from './Globals'
 import { addController, removeController } from './FrameLoop'
 import {
   interpolateTo,
@@ -52,7 +52,7 @@ export default class Controller {
       ;[from, to] = [to, from]
     }
 
-    if (forceImmediate) {
+    if (skipAnimation) {
       immediate = true
     }
 

--- a/src/renderprops/animated/Globals.js
+++ b/src/renderprops/animated/Globals.js
@@ -9,6 +9,7 @@ export let interpolation = undefined
 export let now = () => Date.now()
 export let defaultElement = undefined
 export let createAnimatedStyle = undefined
+export let forceImmediate = false
 
 export const injectApplyAnimatedValues = (fn, transform) =>
   (applyAnimatedValues = { fn, transform })
@@ -21,3 +22,4 @@ export const injectNow = nowFn => (now = nowFn)
 export const injectDefaultElement = el => (defaultElement = el)
 export const injectCreateAnimatedStyle = factory =>
   (createAnimatedStyle = factory)
+export const injectForceImmediate = force => (forceImmediate = force)

--- a/src/renderprops/animated/Globals.js
+++ b/src/renderprops/animated/Globals.js
@@ -9,7 +9,7 @@ export let interpolation = undefined
 export let now = () => Date.now()
 export let defaultElement = undefined
 export let createAnimatedStyle = undefined
-export let forceImmediate = false
+export let skipAnimation = false
 
 export const injectApplyAnimatedValues = (fn, transform) =>
   (applyAnimatedValues = { fn, transform })
@@ -22,4 +22,4 @@ export const injectNow = nowFn => (now = nowFn)
 export const injectDefaultElement = el => (defaultElement = el)
 export const injectCreateAnimatedStyle = factory =>
   (createAnimatedStyle = factory)
-export const injectForceImmediate = force => (forceImmediate = force)
+export const injectSkipAnimation = skip => (skipAnimation = skip)


### PR DESCRIPTION
Based on 98b1649ea2d48323ea2b903d94d8584a594fe990, fixes #668. 

While I realize that v9 is on the way, we have some trouble getting screenshot/visual tests going while migrating some other animation libraries to the stable version of react-spring. I'm reimplementing the v9 disable mechanism to the old API for a way to use this feature immediately until the new version is released.

Would be great if we could get this backport into the version 8 branch/release.