### PR TITLE
Bugfix: make `animated` work with arrow function component

### DIFF
--- a/packages/animated/src/withAnimated.tsx
+++ b/packages/animated/src/withAnimated.tsx
@@ -37,7 +37,8 @@ const createAnimatedComponent = (Component: any) =>
     const hasInstance: boolean =
       // Function components must use "forwardRef" to avoid being
       // re-rendered on every animation frame.
-      !is.fun(Component) || Component.prototype.isReactComponent
+      !is.fun(Component) ||
+      (Component.prototype && Component.prototype.isReactComponent)
 
     const forceUpdate = useForceUpdate()
     const props = new AnimatedProps(() => {


### PR DESCRIPTION
I found out this bug when I'm working on #903: When we pass arrow function component, it will throw error because in `createAnimatedComponent` we check `Component.prototype.isReactComponent` to check if it's component created by `create-react-class`, but arrow function doesn't have `.prototype` property. This commit additionally check if `.prototype` exists to make arrow function component can work with `animated()`.

To test this just try to pass an arrow function component into `animated()`.