### PR TITLE
[Feature] Add resume and pause method into useTransition/useSpring ref api

### DIFF
--- a/packages/core/src/Controller.ts
+++ b/packages/core/src/Controller.ts
@@ -242,6 +242,28 @@ export class Controller<State extends Indexable = UnknownProps>
     return this
   }
 
+  /** Freeze the active animation in time */
+  pause(keys?: OneOrMore<string>) {
+    if (is.und(keys)) {
+      this.each(spring => spring.pause())
+    } else {
+      const springs = this.springs as Indexable<SpringValue>
+      each(toArray(keys), key => springs[key].pause())
+    }
+    return this
+  }
+
+  /** Resume the animation if paused. */
+  resume(keys?: OneOrMore<string>) {
+    if (is.und(keys)) {
+      this.each(spring => spring.resume())
+    } else {
+      const springs = this.springs as Indexable<SpringValue>
+      each(toArray(keys), key => springs[key].resume())
+    }
+    return this
+  }
+
   /** Restart every animation. */
   reset() {
     this.each(spring => spring.reset())

--- a/packages/core/src/types/spring.ts
+++ b/packages/core/src/types/spring.ts
@@ -177,6 +177,30 @@ export type SpringStopFn<T> = T extends object
   : () => void
 
 /**
+ * Pause animating `SpringValue`.
+ *
+ * The `T` parameter can be a set of animated values (as an object type)
+ * or a primitive type for a single animated value.
+ */
+export type SpringPauseFn<T> = T extends object
+  ? T extends ReadonlyArray<number | string>
+    ? () => void
+    : (keys?: OneOrMore<string>) => void
+  : () => void
+
+/**
+ * Resume paused `SpringValue`.
+ *
+ * The `T` parameter can be a set of animated values (as an object type)
+ * or a primitive type for a single animated value.
+ */
+export type SpringResumeFn<T> = T extends object
+  ? T extends ReadonlyArray<number | string>
+    ? () => void
+    : (keys?: OneOrMore<string>) => void
+  : () => void
+
+/**
  * Update the props of each spring, individually or all at once.
  *
  * The `T` parameter should only contain animated props.
@@ -202,6 +226,8 @@ export interface SpringHandle<T extends Indexable = any> {
   update: SpringsUpdateFn<T>
   start: () => AsyncResult<T[]>
   stop: SpringStopFn<T>
+  pause: SpringPauseFn<T>
+  resume: SpringResumeFn<T>
 }
 
 export type SpringConfig = Partial<Omit<AnimationConfig, 'w0'>>

--- a/packages/core/src/useSprings.ts
+++ b/packages/core/src/useSprings.ts
@@ -131,6 +131,8 @@ export function useSprings(
         }
       },
       stop: keys => each(ctrls, ctrl => ctrl.stop(keys)),
+      pause: keys => each(ctrls, ctrl => ctrl.pause(keys)),
+      resume: keys => each(ctrls, ctrl => ctrl.resume(keys)),
     }),
     []
   )

--- a/packages/core/src/useTransition.tsx
+++ b/packages/core/src/useTransition.tsx
@@ -312,6 +312,8 @@ export function useTransition(
         }
       },
       stop: keys => each(usedTransitions.current!, t => t.ctrl.stop(keys)),
+      pause: keys => each(usedTransitions.current!, t => t.ctrl.pause(keys)),
+      resume: keys => each(usedTransitions.current!, t => t.ctrl.resume(keys)),
     }),
     []
   )


### PR DESCRIPTION
Add `pause` and `resume` method in `Controller`, `useSprings` and `useTransition` ref api. I have tried it on my own project and it looks great. If needed I can make a minimal demo.

This change will close #903 .
